### PR TITLE
Prepare for internal SumAll Bloodhound build

### DIFF
--- a/bloodhound.cabal
+++ b/bloodhound.cabal
@@ -1,8 +1,8 @@
-name:                bloodhound
-version:             0.10.0.0
+name:                sumall-bloodhound
+version:             0.11.0.0
 synopsis:            ElasticSearch client library for Haskell
 description:         ElasticSearch made awesome for Haskell hackers
-homepage:            https://github.com/bitemyapp/bloodhound
+homepage:            https://github.com/sumall/bloodhound
 license:             BSD3
 license-file:        LICENSE
 author:              Chris Allen
@@ -19,7 +19,7 @@ extra-source-files:
 
 source-repository head
   type:     git
-  location: https://github.com/bitemyapp/bloodhound.git
+  location: https://github.com/sumall/bloodhound.git
 
 library
   ghc-options: -Wall
@@ -93,4 +93,4 @@ test-suite doctests
 
 Source-Repository head
   Type:     git
-  Location: git://github.com/bitemyapp/bloodhound.git
+  Location: git://github.com/sumall/bloodhound.git


### PR DESCRIPTION
1. Change the library name to sumall-bloodhound
2. Bump major version because the new unreleased content is backwards incompatible
3. Change git repo urls